### PR TITLE
fix module name so example will work in playground

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module goexp
+module github.com/svstanev/goexp
 
 require github.com/go-test/deep v1.0.1


### PR DESCRIPTION
Right now users get this error when trying to run the example at https://play.golang.org/p/mUV8JfA1eeo:
```
go: github.com/svstanev/goexp: github.com/svstanev/goexp@v0.0.0-20190421115513-016d08dbdee7: parsing go.mod:
	module declares its path as: goexp
	        but was required as: github.com/svstanev/goexp
```
A similar error happens when running it locally as well.  This PR fixes both.